### PR TITLE
feat: add pyannote.database configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ Some researchers might find useful a version of diarization references that not 
 
 [1] J. Carletta, S. Ashby, S. Bourban, M. Flynn, M. Guillemot, T. Hain, J. Kadlec, V. Karaiskos, W. Kraaij, M. Kronenthal, et al., The AMI meeting corpus: A pre-announcement, in: International workshop on machine learning for multimodal interaction, Springer, 2006, pp. 28–39.
 
+### pyannote
+
+In order to avoid any future divergence between this repo and [`pyannote.audio`](https://www.github.com/pyannote/pyannote-audio) evaluation protocols, we also [provide](pyannote) the [`pyannote.database`](https://www.github.com/pyannote/pyannote-database) configuration file.
 
 ### Citations
 In case of using the setup, please cite:\

--- a/pyannote/README.md
+++ b/pyannote/README.md
@@ -1,0 +1,28 @@
+# How to use in `pyannote`
+
+
+```python
+# tell pyannote.database where to find partition and reference
+import os
+os.environ["PYANNOTE_DATABASE_CONFIG"] = 'AMI-diarization-setup/pyannote/database.yml'
+
+# initialize 'only_words' experimental protocol
+from pyannote.database import get_protocol
+only_words = get_protocol('AMI.SpeakerDiarization.only_words')
+
+# iterate over the training set
+for file in only_words.train():
+    meeting = file['uri']
+    reference = file['annotation']
+
+# iterate over the development set
+for file in only_words.development():
+    pass
+
+# iterate over the test set
+for file in only_words.test():
+    pass
+
+# initialize 'word_and_vocalsounds' experimental protocol
+word_and_vocalsounds = get_protocol('AMI.SpeakerDiarization.word_and_vocalsounds')
+```

--- a/pyannote/database.yml
+++ b/pyannote/database.yml
@@ -1,0 +1,25 @@
+Protocols:
+  AMI:
+    SpeakerDiarization:
+
+      only_words:
+        train:
+            uri: ../lists/train.meetings.txt
+            annotation: _../only_words/rttms/train/{uri}.rttm
+        development:
+            uri: ../lists/dev.meetings.txt
+            annotation: _../only_words/rttms/dev/{uri}.rttm
+        test:
+            uri: ../lists/test.meetings.txt
+            annotation: _../only_words/rttms/test/{uri}.rttm
+ 
+      word_and_vocalsounds:
+        train:
+            uri: ../lists/train.meetings.txt
+            annotation: _../word_and_vocalsounds/rttms/train/{uri}.rttm
+        development:
+            uri: ../lists/dev.meetings.txt
+            annotation: _../word_and_vocalsounds/rttms/dev/{uri}.rttm
+        test:
+            uri: ../lists/test.meetings.txt
+            annotation: _../word_and_vocalsounds/rttms/test/{uri}.rttm


### PR DESCRIPTION
In order to avoid any future divergence between this repo and pyannote.audio evaluation protocols, I propose to store pyannote.database configuration file in this repo as well.

It would be nice to add `uem` files as well (even if they just contain `0 file_duration` lines).

It would also be nice to add evaluation scripts as well (I can do that based on pyannote.metrics if you are interested).
